### PR TITLE
Extend SinkBase to support DOC-file for frontend ragnarok

### DIFF
--- a/SINK.md
+++ b/SINK.md
@@ -1,8 +1,15 @@
 # Sink (Sink Title?)
+
 Short description of sink
+
 ## Data
+
 Short explanation of what kind of data this sink processes
+
 ## Source
+
 Short description of the organization providing this data
+
 ## Usage
+
 Describe what this data can be used for. Maybe add in a few examples

--- a/SINK.md
+++ b/SINK.md
@@ -1,0 +1,8 @@
+# Sink (Sink Title?)
+Short description of sink
+## Data
+Short explanation of what kind of data this sink processes
+## Source
+Short description of the organization providing this data
+## Usage
+Describe what this data can be used for. Maybe add in a few examples

--- a/src/Sinks/SinkBase.php
+++ b/src/Sinks/SinkBase.php
@@ -4,7 +4,6 @@ namespace Ragnarok\Sink\Sinks;
 
 use Illuminate\Support\Carbon;
 use Ragnarok\Sink\Models\SinkFile;
-use Ragnarok\Sink\Traits\LogPrintf;
 use League\CommonMark\GithubFlavoredMarkdownConverter;
 use ReflectionClass;
 
@@ -16,8 +15,6 @@ use ReflectionClass;
  */
 abstract class SinkBase
 {
-    use LogPrintf;
-
     /**
      * Machine readable ID of sink. Preferably in lower_snake_case
      *

--- a/src/Sinks/SinkBase.php
+++ b/src/Sinks/SinkBase.php
@@ -4,6 +4,9 @@ namespace Ragnarok\Sink\Sinks;
 
 use Illuminate\Support\Carbon;
 use Ragnarok\Sink\Models\SinkFile;
+use Ragnarok\Sink\Traits\LogPrintf;
+use League\CommonMark\GithubFlavoredMarkdownConverter;
+use ReflectionClass;
 
 /**
  * Foundation class for Ragnarok sinks.
@@ -13,6 +16,8 @@ use Ragnarok\Sink\Models\SinkFile;
  */
 abstract class SinkBase
 {
+    use LogPrintf;
+
     /**
      * Machine readable ID of sink. Preferably in lower_snake_case
      *
@@ -49,6 +54,13 @@ abstract class SinkBase
      * @var string
      */
     public $cron = null;
+
+    /**
+     * Filename for sink documentation, defaults to SINK.md
+     *
+     * It is case sensitive. Override in sink implementation if the needed.
+     */
+    public static $docfileName = "SINK.md";
 
     /**
      * List of tables for imported destination data.
@@ -160,5 +172,30 @@ abstract class SinkBase
         //     $hits = preg_match('|(?P<date>\d{4}-\d{2}-\d{2})\.zip$|', $filename, $matches);
         //     return $hits ? $matches['date'] : null;
         // @endcode
+    }
+
+    /**
+     * Get sink documentation from file SINK.md from implemenation root path.
+     * Expects GithubFlavoured Markdown.
+     *
+     * @return string|null Content of SINK.md as html if found.
+     */
+    public function getDocumentation(): string|null
+    {
+        $reflection = new ReflectionClass($this);
+        $filename = $reflection->getFileName();
+        $mdfilename = $reflection->getStaticPropertyValue('docfileName');
+        $pathArray = explode('/', $filename);
+        $pathArray = array_splice($pathArray, 0, -3);
+
+        $docfile = implode('/', $pathArray) . "/{$mdfilename}";
+
+        if (file_exists($docfile)) {
+            $fileContent = file_get_contents($docfile);
+            $converter = new GithubFlavoredMarkdownConverter();
+            return $converter->convert($fileContent);
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
I have tested this by adding SINK.md to the root of a Sink implementation, called `$this->getDocumentation()` from somewhere in Sink (like fetch). Then I've printed the result to log by using LogPrintf.