### PR TITLE
fix: Allow empty CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Added
 - CsvToTable and DbBulkInsert can now have `->dummy()` runs
 
+### Fixed
+- CsvToTable now allows CSV files to be empty or have malformed
+  header. File is then skipped.
+
 ## [0.1.0] – 2024-04-18
 ### Added
 - API for sinks to implement. CRUD for stage 1 data import.

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/console": "^10.0",
         "illuminate/database": "^10.0",
         "illuminate/support": "^10.0",
-        "league/csv": "^9.0",
+        "league/csv": "^9.16.0",
         "league/flysystem": "^3.8.0"
     },
     "require-dev": {


### PR DESCRIPTION
Imported CSVs are sometimes empty. This adds a test for it by checking if there is a header and reports a notice in the log file when empty.
