### PR TITLE
Added support for ZIP containing folders.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Added
 - CsvToTable and DbBulkInsert can now have `->dummy()` runs.
-- ChunkExtractor `->getAllFiles()` adds support for ZIP files
-  containing multiple directory levels.
+- ChunkExtractor `->getFiles()` now takes an optional parameter which
+  adds support for ZIP files containing multiple directory levels.
 
 ### Fixed
 - CsvToTable now allows CSV files to be empty or have malformed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## [Unreleased]
 
 ### Added
-- CsvToTable and DbBulkInsert can now have `->dummy()` runs
+- CsvToTable and DbBulkInsert can now have `->dummy()` runs.
+- ChunkExtractor `->getAllFiles()` adds support for ZIP files
+  containing multiple directory levels.
 
 ### Fixed
 - CsvToTable now allows CSV files to be empty or have malformed

--- a/src/Services/ChunkExtractor.php
+++ b/src/Services/ChunkExtractor.php
@@ -95,29 +95,18 @@ class ChunkExtractor
     /**
      * Get all files within zip file.
      *
-     * @return mixed[]
-     */
-    public function getFiles(): array
-    {
-        if ($this->destDir === null) {
-            $this->extract();
-        }
-        $disk = $this->localFile->getDisk();
-        return array_map(fn ($item) => $disk->path($item), $disk->files($this->destDir));
-    }
-
-    /**
-     * Get all files within zip file, including files within folders.
+     * @param bool $recursive Include files within subdirectories.
      *
-     * @return array Full path to each file
+     * @return array Full path to each file.
      */
-    public function getAllFiles(): array
+    public function getFiles($recursive = false): array
     {
         if ($this->destDir === null) {
             $this->extract();
         }
         $disk = $this->localFile->getDisk();
-        return array_map(fn ($item) => $disk->path($item), $disk->allFiles($this->destDir));
+        $files = $recursive ? $disk->allFiles($this->destDir) : $disk->files($this->destDir);
+        return array_map(fn ($item) => $disk->path($item), $files);
     }
 
     public function close(): ChunkExtractor

--- a/src/Services/ChunkExtractor.php
+++ b/src/Services/ChunkExtractor.php
@@ -106,6 +106,20 @@ class ChunkExtractor
         return array_map(fn ($item) => $disk->path($item), $disk->files($this->destDir));
     }
 
+    /**
+     * Get all files within zip file, including files within folders.
+     *
+     * @return array Full path to each file
+     */
+    public function getAllFiles(): array
+    {
+        if ($this->destDir === null) {
+            $this->extract();
+        }
+        $disk = $this->localFile->getDisk();
+        return array_map(fn ($item) => $disk->path($item), $disk->allFiles($this->destDir));
+    }
+
     public function close(): ChunkExtractor
     {
         if ($this->destDir === null) {


### PR DESCRIPTION
The new `ChunkExtractor::getAllFiles()` function adds support for ZIP files containing multiple directory levels. It will also work with flat ZIP files.